### PR TITLE
Various docs improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## Description ##
 
-Allows seamless embedding for the Storytelling Tools
+Allows seamless embedding for the Knight Lab Storytelling Tools
 
 ## Installation ##
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ You can learn more information about the Storytelling Tools at https://knightlab
 
 ## Screenshots ##
 
+1. Example of the Juxtapose embed
+![](assets/screenshot-1.gif)
+
+2. Example of the Timeline embed
+![](assets/screenshot-2.gif)
 
 ## Changelog ##
 

--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ The Knight Lab at Northwestern University has created 4 storytelling tools to he
 
 This plugin seamlessly integrates those tools into WordPress, using the methods listed below:
 
-1. Timeline
+1. [Timeline](http://timeline.knightlab.com/):
 Easy-to-make, beautiful timelines.
 This plugin adds embed support for timelines created at http://timeline.knightlab.com/. Simply paste the URL to the timeline you've created, and WordPress will embed an iframe of the content in it's place.
 
-2. StoryMap
+2. [StoryMap](https://storymap.knightlab.com/):
 Maps that tell stories.
 This plugin adds embed support for storymaps created at https://storymap.knightlab.com/. Simply paste the URL to the storymap you've created, and WordPress will embed an iframe of the content in it's place.
 
-3. Juxtapose
+3. [Juxtapose](https://juxtapose.knightlab.com/);
 Easy-to-make frame comparisons.
 This plugin adds embed support for image comparisons created at https://juxtapose.knightlab.com/. Simply paste the URL to the item you've created, and WordPress will embed an iframe of the content in it's place.
 
-4. Soundcite
+4. [Soundcite](http://soundcite.knightlab.com/):
 Seamless inline audio.
 This plugin adds a shortcode that allows you to embed an mp3 file as an inline text within a story. The plugin will automatically include the Soundcite JavaScript file on pages using the shortcode (in order to create the audio player).
 You can learn more and see examples of this tool in action at http://soundcite.knightlab.com/

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This plugin adds embed support for image comparisons created at https://juxtapos
 
 4. [Soundcite](http://soundcite.knightlab.com/):
 Seamless inline audio.
-This plugin adds a shortcode that allows you to embed an mp3 file as an inline text within a story. The plugin will automatically include the Soundcite JavaScript file on pages using the shortcode (in order to create the audio player).
+This plugin adds a shortcode that allows you to embed an mp3 file as an inline text within a story. The plugin will automatically include the Soundcite JavaScript file and stylesheet on pages using the shortcode (in order to create the audio player). The shortcode's arguments are `url`, `text`, `start`, and `end`. `url` is the URL of [a compatible audio file](http://soundcite.knightlab.com/#make). `start` and `end` are optional, but can be used to specify the time in seconds (not milliseconds) when playback should start and stop in the file.
 You can learn more and see examples of this tool in action at http://soundcite.knightlab.com/
 
 You can learn more information about the Storytelling Tools at https://knightlab.northwestern.edu/projects/

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Storytelling Tools #
-**Contributors:**      innlabs, rclations
+**Contributors:**      innlabs, rclations  
 **Donate link:**       https://labs.inn.org  
 **Tags:**  
 **Requires at least:** 4.4  
-**Tested up to:**      4.8
+**Tested up to:**      4.8  
 **Stable tag:**        1.1  
 **License:**           GPLv2  
 **License URI:**       http://www.gnu.org/licenses/gpl-2.0.html  

--- a/readme.txt
+++ b/readme.txt
@@ -30,7 +30,7 @@ This plugin adds embed support for image comparisons created at https://juxtapos
 
 4. [Soundcite](http://soundcite.knightlab.com/):
 Seamless inline audio.
-This plugin adds a shortcode that allows you to embed an mp3 file as an inline text within a story. The plugin will automatically include the Soundcite javascript file on pages using the shortcode (in order to create the audio player).
+This plugin adds a shortcode that allows you to embed an mp3 file as an inline text within a story. The plugin will automatically include the Soundcite JavaScript file and stylesheet on pages using the shortcode (in order to create the audio player). The shortcode's arguments are `url`, `text`, `start`, and `end`. `url` is the URL of [a compatible audio file](http://soundcite.knightlab.com/#make). `start` and `end` are optional, but can be used to specify the time in seconds (not milliseconds) when playback should start and stop in the file.
 You can learn more and see examples of this tool in action at http://soundcite.knightlab.com/
 
 You can learn more information about the Storytelling Tools at https://knightlab.northwestern.edu/projects/

--- a/readme.txt
+++ b/readme.txt
@@ -16,19 +16,19 @@ The Knight Lab at Northwestern University has created 4 storytelling tools to he
 
 This plugin seamlessly integrates those tools into WordPress, using the methods listed below:
 
-1. Timeline
+1. [Timeline](http://timeline.knightlab.com/):
 Easy-to-make, beautiful timelines.
 This plugin adds embed support for timelines created at http://timeline.knightlab.com/. Simply paste the URL to the timeline you've created, and WordPress will embed an iframe of the content in it's place.
 
-2. StoryMap
+2. [StoryMap](https://storymap.knightlab.com/):
 Maps that tell stories.
 This plugin adds embed support for storymaps created at https://storymap.knightlab.com/. Simply paste the URL to the storymap you've created, and WordPress will embed an iframe of the content in it's place.
 
-3. Juxtapose
+3. [Juxtapose](https://juxtapose.knightlab.com/);
 Easy-to-make frame comparisons.
 This plugin adds embed support for image comparisons created at https://juxtapose.knightlab.com/. Simply paste the URL to the item you've created, and WordPress will embed an iframe of the content in it's place.
 
-4. Soundcite
+4. [Soundcite](http://soundcite.knightlab.com/):
 Seamless inline audio.
 This plugin adds a shortcode that allows you to embed an mp3 file as an inline text within a story. The plugin will automatically include the Soundcite javascript file on pages using the shortcode (in order to create the audio player).
 You can learn more and see examples of this tool in action at http://soundcite.knightlab.com/

--- a/readme.txt
+++ b/readme.txt
@@ -8,7 +8,7 @@ Stable tag: 1.1
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Allows seamless embedding for the Storytelling Tools
+Allows seamless embedding for the Knight Lab Storytelling Tools
 
 == Description ==
 


### PR DESCRIPTION
## Changes

- Explains that these are the Knight Lab tools
- Links to tool names
- Adds `[soundcite]` shortcode argument descriptions in docs, but we need that to be user-facing.

Specifically in README.md:

- fixes top-of-file formatting

For https://github.com/INN/storytelling-tools/issues/5