### PR TITLE
Add support for timelinejs v3 and bump version numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:**  
 **Requires at least:** 4.4  
 **Tested up to:**      4.8
-**Stable tag:**        1.1  
+**Stable tag:**        1.2  
 **License:**           GPLv2  
 **License URI:**       http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -49,6 +49,10 @@ You can learn more information about the Storytelling Tools at https://knightlab
 
 
 ## Changelog ##
+
+### 1.2 ###
+* Add support for TimelineJS version 3, introduced in summer 2017
+* Minor text fixes
 
 ### 1.1 ###
 * WordPress.com VIP check fixes - better escaping & encoding

--- a/includes/class-embeds.php
+++ b/includes/class-embeds.php
@@ -45,6 +45,11 @@ class KLST_Embeds {
 			array( $this, 'wp_embed_knight_lab_timeline' )
 		);
 		wp_embed_register_handler(
+			'knight-lab-timeline3',
+			'#https://cdn\.knightlab\.com/libs/timeline3/latest/embed/index.html\?source=[a-zA-Z0-9_-]+#i',
+			array( $this, 'wp_embed_knight_lab_timeline3' )
+		);
+		wp_embed_register_handler(
 			'knight-lab-juxtapose',
 			'#https://cdn\.knightlab\.com/libs/juxtapose/latest/embed/index\.html\?uid=([a-zA-Z0-9_-]+)#i',
 			array( $this, 'wp_embed_knight_lab_juxtapose' )
@@ -70,6 +75,7 @@ class KLST_Embeds {
 	 * @param  array  $attr		attributes.
 	 * @param  string $url 		url.
 	 * @param  array  $rawattr	raw matches.
+	 * @link https://github.com/NUKnightLab/TimelineJS
 	 */
 	public function wp_embed_knight_lab_timeline( $matches, $attr, $url, $rawattr ) {
 
@@ -81,7 +87,7 @@ class KLST_Embeds {
 			'font' => '',
 			'lang' => '',
 			'initial_zoom' => '4',
-			'width' => '100%%',
+			'width' => '100%%', # %% because we're passing this through sprintf and need to escape the %
 			'height' => '650',
 		);
 
@@ -89,6 +95,47 @@ class KLST_Embeds {
 
 		$embed = sprintf(
 			'<iframe src="https://cdn.knightlab.com/libs/timeline/latest/embed/?source=%1$s&font=%2$s&lang=%3$s&initial_zoom=%4$s&width=%5$s&height=%6$s" width="%7$s" height="%8$s" webkitallowfullscreen mozallowfullscreen allowfullscreen frameborder="0"></iframe>',
+			rawurlencode( $args['source'] ),
+			rawurlencode( $args['font'] ),
+			rawurlencode( $args['lang'] ),
+			rawurlencode( $args['initial_zoom'] ),
+			rawurlencode( $args['width'] ),
+			rawurlencode( $args['height'] ),
+			esc_attr( $args['width'] ),
+			esc_attr( $args['height'] )
+		);
+		return apply_filters( 'embed_knight_lab_timeline', $embed, $matches, $attr, $url, $rawattr );
+	}
+
+	/**
+	 * Timeline3 embed.
+	 *
+	 * @since  1.2.0
+	 *
+	 * @param  array  $matches	regex matches.
+	 * @param  array  $attr		attributes.
+	 * @param  string $url 		url.
+	 * @param  array  $rawattr	raw matches.
+	 * @link https://github.com/NUKnightLab/TimelineJS3
+	 */
+	public function wp_embed_knight_lab_timeline3( $matches, $attr, $url, $rawattr ) {
+
+		$parsed_url = wp_parse_url( $url );
+		parse_str( $parsed_url['query'], $args );
+
+		$defaults = array(
+			'source' => '',
+			'font' => '',
+			'lang' => '',
+			'initial_zoom' => '4',
+			'width' => '100%%', # %% because we're passing this through sprintf and need to escape the %
+			'height' => '650',
+		);
+
+		$args = wp_parse_args( $args, $defaults );
+
+		$embed = sprintf(
+			'<iframe src="https://cdn.knightlab.com/libs/timeline3/latest/embed/?source=%1$s&font=%2$s&lang=%3$s&initial_zoom=%4$s&width=%5$s&height=%6$s" width="%7$s" height="%8$s" webkitallowfullscreen mozallowfullscreen allowfullscreen frameborder="0"></iframe>',
 			rawurlencode( $args['source'] ),
 			rawurlencode( $args['font'] ),
 			rawurlencode( $args['lang'] ),
@@ -113,6 +160,7 @@ class KLST_Embeds {
 	 */
 	public function wp_embed_knight_lab_storymap( $matches, $attr, $url, $rawattr ) {
 		$embed = sprintf(
+			# %% because we need to escape it inside sprintf
 			'<iframe src="https://uploads.knightlab.com/storymapjs/%1$s/%2$s/index.html" frameborder="0" width="100%%" height="800"></iframe>',
 			rawurlencode( $matches[1] ),
 			rawurlencode( $matches[2] )
@@ -132,6 +180,7 @@ class KLST_Embeds {
 	 */
 	public function wp_embed_knight_lab_juxtapose( $matches, $attr, $url, $rawattr ) {
 		$embed = sprintf(
+			# %% because we need to escape it inside sprintf
 			'<iframe frameborder="0" class="juxtapose" width="100%%" height="360" src="https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=%1$s"></iframe>',
 			rawurlencode( $matches[1] )
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://labs.inn.org
 Tags:
 Requires at least: 4.4
 Tested up to: 4.8
-Stable tag: 1.1
+Stable tag: 1.2
 License: GPLv2
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -47,6 +47,10 @@ You can learn more information about the Storytelling Tools at https://knightlab
 2. Example of the Timeline embed
 
 == Changelog ==
+
+= 1.2 =
+* Add support for TimelineJS version 3, introduced in summer 2017
+* Minor text fixes
 
 = 1.1 =
 * WordPress.com VIP check fixes - better escaping & encoding

--- a/storytelling-tools.php
+++ b/storytelling-tools.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Storytelling Tools
  * Description: Allows seamless embedding for the Storytelling Tools
- * Version:     1.1
+ * Version:     1.2
  * Author:      innlabs
  * Author URI:  https://labs.inn.org
  * Donate link: https://labs.inn.org


### PR DESCRIPTION
## Changes

- Adds support for Timeline JS version 3, introduced this summer, that has slightly different URL formats
- Bumps version number to 1.2

## Why

Because the timeline.knightlab.com site is currently giving out URLs that are not compatible with the 1.1 release of this plugin.

For #7